### PR TITLE
Add styles to hide empty leading p tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,6 +120,18 @@ article > .article-header {
 .actions-footer a:hover {
 	background: #c60c30;
 }
+/* Empty leading p tags from builder */
+.column > p:first-child:empty {
+	padding: 0;
+}
+.column > p:first-child:empty + h1,
+.column > p:first-child:empty + h2,
+.column > p:first-child:empty + h3,
+.column > p:first-child:empty + h4,
+.column > p:first-child:empty + h5,
+.column > p:first-child:empty + h6 {
+	padding-top: 0;
+}
 /* Contact form */
 .county-contact-form {
 	margin: 0;


### PR DESCRIPTION
@danialbleile Just thought of this as one potential way to deal with the shortcode/p tag issue - doesn't fix it, but at least hides it. Feel free to merge and deploy if you like it, or not if you don't.
